### PR TITLE
HD derivation of Bitmessage addresses

### DIFF
--- a/bips/bip-bm01.mediawiki
+++ b/bips/bip-bm01.mediawiki
@@ -1,0 +1,77 @@
+<pre>
+  BIP:     BM01
+  Title:   Hierarchy for Bitmessage Key Derivations
+  Authors: Justus Ranvier <justus@monetas.net>
+  Status:  Draft
+  Type:    Informational
+  Created: 2015-06-10
+</pre>
+
+==Abstract==
+
+This BIP defines a logical hierarchy for deriving encryption and signing keys used for Bitmessage based on an algorithm described in BIP-0032 (BIP32 from now on) and purpose scheme described in BIP-0043 (BIP43 from now on).
+
+This BIP is a particular application of BIP43 and is based on BIP44.
+
+==Motivation==
+
+The hierarchy proposed in this paper allows for Bitmessage users to derive all their keys from a single seed, which may be the same seed used for a Bitcoin wallet.
+
+==Path levels==
+
+We define the following 4 levels in BIP32 path:
+
+<pre>
+m / purpose' / identity' / stream' / signing_key
+</pre>
+
+Apostrophe in the path indicates that BIP32 hardened derivation is used.
+
+Each level has a special meaning, described in the chapters below.
+
+===Purpose===
+
+Purpose is a constant set to BM01 (or 0x424D3031) following the BIP43 recommendation. It indicates that the subtree of this node is used according to this specification.
+
+Hardened derivation is used at this level.
+
+===Identity===
+
+Identity is used to derive different key groups for identity seperation.
+
+Identities are numbered from index 0 in a sequentially increasing manner.
+
+===Stream===
+
+Stream is used to derive different keys for use in different Bitmessage streams
+
+Streams are numbered from index 1.
+
+===Signing===
+
+Public/private keypairs for signing are numbered from index 0 in sequentially increasing manner. This number is used as child index in BIP32 derivation.
+
+Public derivation is used at this level.
+
+===Encryption Keys===
+
+Bitmessage does not allow for arbitrary combinations of signing an encryption keys. In order to form a valid Bitmessage address, the keys must satisfy the condition that: <pre>ripemd160(sha512(concatenate(signing public key, encryption public key))</pre> contains a leading zero when the public keys are expressed in uncompressed X9.62 format.
+
+Encryption keys are derived from signing keys using the following method:
+
+# Derive a signing key per the procedure above: <pre>B</pre>
+# Initialize a counter at 1: <pre>n</pre>
+# Derive a candidate encryption key: <pre>B' = B + nG</pre>
+# If the combination of B and B` do not satisfy the acceptance criteria, increment n by one and try again
+# Use the address version, signing key, encryption key, and stream number to construct a Bitmessage address per the Bitmessage protocol
+
+==Compatible implementations==
+
+* [[https://github.com/monetas/bmd|bmd]] is the reference Bitmessage implementation which uses this specification
+
+==Reference==
+
+* [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]
+* [[bip-0043.mediawiki|BIP43 - Purpose Field for Deterministic Wallets]]
+* [[bip-0044.mediawiki|BIP44 - Multi-Account Hierarchy for Deterministic Wallets]]
+* [[https://bitmessage.org/wiki/Public_key_to_bitmessage_address|Public key to bitmessage address]]


### PR DESCRIPTION
This specification allows a multiple-identity Bitmessage client to derive all needed keypairs from a single seed, which may be the same seed used to derive Bitcoin keypairs without the possibility of collision, greatly simplifying backup requirements and improving the user experience.
